### PR TITLE
Upgrade to 2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,9 +138,9 @@ ROOT_HOME = "/root"
 [comment]: <> (-------------------------------------------------------------------------)
 
 <details>
-<summary>IMX 6.6 scarthgap Linux releases</summary>
+<summary>IMX 93 FRDM 6.6 scarthgap Linux releases</summary>
 
-This process has been tested with FRDM-IMX93, but it should support other IMX MPU boards with that can load the 
+This process has been tested with FRDM-IMX93, but it should support other IMX MPU boards that can load the 
 6.6 scarthgap Linux release.
 
 While the default image on the device's eMMC could work as well, and even be restored or upgraded using the *uuu* tool,
@@ -148,8 +148,7 @@ we recommend using an SD Card instead, so that the eMMC stays pristine and the i
 
 From 
 [this link](https://www.nxp.com/design/design-center/development-boards-and-designs/frdm-i-mx-93-development-board:FRDM-IMX93#software)
-, download the FRDM-IMX93 Demo Images (LF_v6.6.36-2.1.0_images_FRDM_1.0_i.MX93) package.
-
+, download the **FRDM-IMX93 Demo Images Rev 1.0** (LF_v6.6.36-2.1.0_images_FRDM_1.0_i.MX93) package.
 
 Use an adequate tool for your system to flash the **imx-image-full-imx93frdm.rootfs.wic.zst** image - *dd* on Linux
 , Rufus, Balena Etcher and similar on other OS-es. 
@@ -165,11 +164,12 @@ where sdX will be your SDcard device listed by ```lsblk```.
 
 Consult the *FRDM i.MX 93 Development Board Quick Start Guide* from the 
 [Documentation Section](https://www.nxp.com/design/design-center/development-boards-and-designs/frdm-i-mx-93-development-board:FRDM-IMX93#documentation)
-on how to connect the USB ports, setup network, and configure the SW1 boot switch. To boot from an SD card
-, ensure that the board's *SW1 BOOT* switches are set to *0011* (4 to 1) configuration
-before booting up the device.
+on how to connect the USB ports, setup network, and configure the SW1 boot switch at the center of the board. 
+To boot from an SD card, ensure that the board's *SW1 BOOT* switches are set to *0011* (4 to 1) configuration
+before booting up the device. The switch positions will be UP-UP-DOWN-DOWN.
 
-Connect to either the USB serial console, or SSH to the device as root user.
+Connect to either the USB serial console, or SSH to the device as root user once you find the IP address of it 
+on your router or a tool like *nmap*.
 
 At the console prompt enter:
 ```shell

--- a/installer/imx/device-setup.sh
+++ b/installer/imx/device-setup.sh
@@ -55,8 +55,9 @@ apt remove -y aws-greengrass-lite 2> /dev/null || :
 rm -rf /tmp/ggl-install
 mkdir -p /tmp/ggl-install
 pushd /tmp/ggl-install >/dev/null
-wget -nv https://github.com/aws-greengrass/aws-greengrass-lite/releases/download/v2.3.0/aws-greengrass-lite-deb-arm64.zip
-unzip -q -o aws-greengrass-lite-deb-arm64.zip
+zip_file=aws-greengrass-lite-deb-arm64.zip
+wget -nv https://github.com/aws-greengrass/aws-greengrass-lite/releases/download/v2.3.0/${zip_file}
+unzip -q -${zip_file}
 deb_package="$(ls -1 aws-greengrass-lite-*-Linux.deb | head -n1)"
 remove_all_deps() {
   deb_package="$1"

--- a/installer/imx/device-setup.sh
+++ b/installer/imx/device-setup.sh
@@ -57,7 +57,7 @@ mkdir -p /tmp/ggl-install
 pushd /tmp/ggl-install >/dev/null
 zip_file=aws-greengrass-lite-deb-arm64.zip
 wget -nv https://github.com/aws-greengrass/aws-greengrass-lite/releases/download/v2.3.0/${zip_file}
-unzip -q -${zip_file}
+unzip -q ${zip_file}
 deb_package="$(ls -1 aws-greengrass-lite-*-Linux.deb | head -n1)"
 remove_all_deps() {
   deb_package="$1"

--- a/installer/imx/device-setup.sh
+++ b/installer/imx/device-setup.sh
@@ -55,7 +55,7 @@ apt remove -y aws-greengrass-lite 2> /dev/null || :
 rm -rf /tmp/ggl-install
 mkdir -p /tmp/ggl-install
 pushd /tmp/ggl-install >/dev/null
-wget -nv https://github.com/aws-greengrass/aws-greengrass-lite/releases/download/v2.3.0/aws-greengrass-lite-ubuntu-arm64.zip
+wget -nv https://github.com/aws-greengrass/aws-greengrass-lite/releases/download/v2.3.0/aws-greengrass-lite-deb-arm64.zip
 unzip -q -o aws-greengrass-lite-deb-arm64.zip
 deb_package="$(ls -1 aws-greengrass-lite-*-Linux.deb | head -n1)"
 remove_all_deps() {

--- a/installer/imx/device-setup.sh
+++ b/installer/imx/device-setup.sh
@@ -55,8 +55,8 @@ apt remove -y aws-greengrass-lite 2> /dev/null || :
 rm -rf /tmp/ggl-install
 mkdir -p /tmp/ggl-install
 pushd /tmp/ggl-install >/dev/null
-wget -nv https://github.com/aws-greengrass/aws-greengrass-lite/releases/download/v2.2.2/aws-greengrass-lite-ubuntu-arm64.zip
-unzip -q -o aws-greengrass-lite-ubuntu-arm64.zip
+wget -nv https://github.com/aws-greengrass/aws-greengrass-lite/releases/download/v2.3.0/aws-greengrass-lite-ubuntu-arm64.zip
+unzip -q -o aws-greengrass-lite-deb-arm64.zip
 deb_package="$(ls -1 aws-greengrass-lite-*-Linux.deb | head -n1)"
 remove_all_deps() {
   deb_package="$1"
@@ -71,6 +71,8 @@ remove_all_deps() {
 }
 # if we don't do this, apt will always complain about unmet dependencies, but our best option was to install similar ones
 remove_all_deps ${deb_package}
+systemctl stop greengrass-lite.target 2>/dev/null || :
+apt remove -y aws-greengrass-lite >/dev/null 2>/dev/null || :
 dpkg -i "./${deb_package}"
 popd >/dev/null
 rm -rf /tmp/ggl-install

--- a/installer/openstlinux/device-setup.sh
+++ b/installer/openstlinux/device-setup.sh
@@ -62,6 +62,17 @@ function mp1_install_build_packages {
   echo Done installing development packages.
 }
 
+function mp2_install_build_packages {
+  # Sometimes the system will need to natively compile some packages.
+  # Specifically awsiotsdk will be needed by all our Greengrass Components it ant will want awscrt compiled.
+  # python3-cffi would be needed to compile the cryptography package on the device. May be needed in the future
+  # for the iotconnect-rest-api python package.
+  # The rest of the packages would setup a proper development environment.
+  echo Installing development packages...
+  apt -q -y install python3-cffi make gcc g++ gcc-symlinks cpp-symlinks g++-symlinks binutils libc6-extra-nss libnss-db2 libc-malloc-debug0
+  echo Done installing development packages.
+}
+
 function mp1_build_wheel_cache {
   # Pre-build python packages needed by the SDK and demos.
   # Otherwise this would take very long time during component installs
@@ -222,6 +233,7 @@ if [[ "$(uname -m)" == "armv7l" ]]; then
   mp1_build_wheel_cache
 elif [[ "$(uname -m)" == "aarch64" ]]; then
   broad_arch=arm64
+  mp2_install_build_packages
   st_repo=STM32MP2_AWS-IoT-Greengrass-nucleus-lite
   st_revision=7bb5243512bc18fffef75fd7d7df728f8cba7725
 else

--- a/installer/openstlinux/device-setup.sh
+++ b/installer/openstlinux/device-setup.sh
@@ -127,9 +127,9 @@ function mp1_build_wheel_cache {
 function install_ggl {
   # This is a blend between the installation from the ST's repo
   # and the install scripts from AWS published aarch64 debian package
-  # We pick up the binaries from ST, but leave the services and other stuff running as ggcore
-  # as intended by AWS
+  # We pick up the binaries from ST, but force install of the deb without deps
 
+  ### Install deps
   rm -rf /tmp/ggl-install
   mkdir -p /tmp/ggl-install
   pushd /tmp/ggl-install>/dev/null
@@ -137,32 +137,39 @@ function install_ggl {
   pushd "${st_repo}" >/dev/null
   git reset --hard ${st_revision}
   dpkg -i gg_lite/*.deb # install deps
-  popd >/dev/null # out of $repo..
+  popd >/dev/null # out of st_repo
+  rm -rf "${st_repo}"
 
-
-  # it is actually a tgz but for some reason with .gz extension
-  tar xf "${st_repo}/gg_lite/gglite.gz"
-  chown -R root:root ./aws-greengrass-lite
-  cp -f ./aws-greengrass-lite/bin/* /usr/bin/.
-  cp -rf ./aws-greengrass-lite/lib/tmpfiles.d /usr/lib/
-  # do not pick up the systemd unit files (see below)
-  mkdir -p /var/lib/greengrass
-
-  zip_file=aws-greengrass-lite-ubuntu-arm64.zip
+  ### Get the zip and extract the deb
+  zip_file=aws-greengrass-lite-deb-${broad_arch}.zip
   rm -f "${zip_file}"
   wget -nv \
-    "https://github.com/aws-greengrass/aws-greengrass-lite/releases/download/v2.2.2/${zip_file}" \
+    "https://github.com/aws-greengrass/aws-greengrass-lite/releases/download/v2.3.0/${zip_file}" \
     -O "${zip_file}"
   rm -f -- *.deb
   unzip -q -o "${zip_file}"
 
-  #deb_package="$(ls -1 aws-greengrass-lite-*-Linux.deb | head -n1)"
-  dpkg-deb --raw-extract aws-greengrass-lite-*-Linux.deb ./pkg
+  ### Remove deps from deb package and install it
+  deb_package="$(ls -1 aws-greengrass-lite-*-Linux.deb | head -n1)"
+  dpkg-deb -e "$deb_package"
+  sed -i '/^Depends:/d' DEBIAN/control
+  pushd DEBIAN >/dev/null
+  tar -czf ../control.tar.gz .
+  popd >/dev/null
+  ar r "$deb_package" control.tar.gz
+  rm -rf ./DEBIAN
+  rm -f control.tar.gz
 
-  # here we pick up the proper systemd files
-  cp -rf pkg/lib/systemd/* /lib/systemd
-  bash -x pkg/DEBIAN/postinst
-
+  ### Now install the deb without deps
+  set +x # avoid output confusion
+  echo "--------------------------------------------"
+  echo " The setup process will now install the Greengrass Lite package."
+  echo " This process may take some time..."
+  echo "--------------------------------------------"
+  set -x
+  systemctl stop greengrass-lite.target 2>/dev/null || :
+  apt remove -y aws-greengrass-lite >/dev/null 2>/dev/null || :
+  dpkg -i "./${deb_package}"
 
   popd >/dev/null # out of $repo..
   rm -rf /tmp/ggl-install
@@ -208,11 +215,13 @@ END
 # It should be the case that mp1 is armv7l and the mp2 should be aarch64
 # Use only revisions that are known to work. We don't want future changes to break something.
 if [[ "$(uname -m)" == "armv7l" ]]; then
+  broad_arch=armv7
   st_repo=STM32MP1_AWS-IoT-Greengrass-nucleus-lite
   st_revision=c10b35f73eec09bdc9818a67e871304966db74d4
   mp1_install_build_packages
   mp1_build_wheel_cache
 elif [[ "$(uname -m)" == "aarch64" ]]; then
+  broad_arch=arm64
   st_repo=STM32MP2_AWS-IoT-Greengrass-nucleus-lite
   st_revision=7bb5243512bc18fffef75fd7d7df728f8cba7725
 else

--- a/installer/ubuntu/device-setup.sh
+++ b/installer/ubuntu/device-setup.sh
@@ -54,17 +54,20 @@ esac
 systemctl stop greengrass-lite.target || :
 apt remove -y aws-greengrass-lite 2> /dev/null || :
 
-zip_file=aws-greengrass-lite-ubuntu-${arch_suffix}.zip
+zip_file=aws-greengrass-lite-deb-${arch_suffix}.zip
 mkdir -p /tmp/ggl-download
 pushd /tmp/ggl-download >/dev/null
 wget -nv \
-  "https://github.com/aws-greengrass/aws-greengrass-lite/releases/download/v2.2.2/${zip_file}" \
+  "https://github.com/aws-greengrass/aws-greengrass-lite/releases/download/v2.3.0/${zip_file}" \
   -O "${zip_file}"
 unzip -o "${zip_file}"
 if [[ $release_ok != yes ]]; then
     echo "WARNING: This deb package will likely only install on Ubuntu 24.xx versions!"
 fi
+
 deb_package="$(ls -1 aws-greengrass-lite-*-Linux.deb | head -n1)"
+systemctl stop greengrass-lite.target 2>/dev/null || :
+apt remove -y aws-greengrass-lite >/dev/null 2>/dev/null || :
 apt install -y ./"${deb_package}"
 popd >/dev/null
 rm -rf /tmp/ggl-download


### PR DESCRIPTION
- Use the latest binary for MPx, as opposed to the ST's github repo binaries.
- Test GGL AWS release binaries on all devices